### PR TITLE
[KCM-3645] - Deploy Nvidia DCGM Helm Chart via Argo

### DIFF
--- a/argocd/apps/demo/prometheus/values.yaml
+++ b/argocd/apps/demo/prometheus/values.yaml
@@ -34,8 +34,3 @@ prometheus:
         endpoints:
           - port: metrics
             interval: 30s
-
-prometheus-pushgateway:
-  enabled: false
-alertmanager:
-  enabled: false

--- a/argocd/apps/demo/prometheus/values.yaml
+++ b/argocd/apps/demo/prometheus/values.yaml
@@ -1,16 +1,41 @@
+prometheusOperator:
+  enabled: true
+
+grafana:
+  enabled: false
+
+alertmanager:
+  enabled: false
+
+prometheus:
+  prometheusSpec:
+    serviceMonitorSelectorNilUsesHelmValues: false
+    additionalScrapeConfigs:
+      - job_name: opencost
+        honor_labels: true
+        scrape_interval: 1m
+        scrape_timeout: 10s
+        metrics_path: /metrics
+        scheme: http
+        dns_sd_configs:
+        - names:
+          - opencost-demo.opencost
+          type: 'A'
+          port: 9003
+
+    additionalServiceMonitors:
+      - name: "dcgm-exporter"
+        namespaceSelector:
+          matchNames:
+            - dcgm-exporter
+        selector:
+          matchLabels:
+            app: dcgm-exporter
+        endpoints:
+          - port: metrics
+            interval: 30s
+
 prometheus-pushgateway:
   enabled: false
 alertmanager:
   enabled: false
-extraScrapeConfigs: |
-  - job_name: opencost
-    honor_labels: true
-    scrape_interval: 1m
-    scrape_timeout: 10s
-    metrics_path: /metrics
-    scheme: http
-    dns_sd_configs:
-    - names:
-      - opencost-demo.opencost
-      type: 'A'
-      port: 9003

--- a/argocd/appsets/prometheus-argo.yaml
+++ b/argocd/appsets/prometheus-argo.yaml
@@ -20,8 +20,8 @@ spec:
       project: default
       sources:
         - repoURL: https://prometheus-community.github.io/helm-charts
-          targetRevision: 27.5.1
-          chart: prometheus
+          targetRevision: 70.3.0
+          chart: kube-prometheus-stack
           helm:
             valueFiles:
             - '$values/argocd/apps/{{ index .path.segments 2 }}/prometheus/values.yaml'


### PR DESCRIPTION
Nvidia-DCGM requires the `ServiceMonitor` CRD, which is not included in the Prometheus Helm chart, since the Prometheus Helm chart doesn't include the Prometheus Operator. The kube-prometheus-stack Helm chart includes the Prometheus Operator, whcih includes the `ServiceMonitor` CRD by default. 

This PR includes changes to use the `kube-prometheus-stack` Helm chart instead of the `prometheus` Helm chart. 