### PR TITLE
Set Prometheus Resource Requests and Limits

### DIFF
--- a/argocd/apps/demo/prometheus/values.yaml
+++ b/argocd/apps/demo/prometheus/values.yaml
@@ -10,6 +10,12 @@ alertmanager:
 prometheus:
   prometheusSpec:
     serviceMonitorSelectorNilUsesHelmValues: false
+    resources:
+      requests:
+        cpu: 3500m
+        memory: 4Gi
+      limits:
+        memory: 25Gi
     storageSpec:
       volumeClaimTemplate:
         spec:


### PR DESCRIPTION
This PR allocates more resources to Prometheus to prevent issues with tests caused by resource constraints. 