### PR TITLE
impl chaos monkey targeting network load generator

### DIFF
--- a/.github/workflows/nightly-clean-up-stacks.yaml
+++ b/.github/workflows/nightly-clean-up-stacks.yaml
@@ -43,7 +43,7 @@ jobs:
                     echo "current namespaces:"
                     kubectl get ns -o name
                     echo "--------------------------------"
-                    allowlist="cnpg-system network-load-gen network-costs argo cert-manager default folding-at-home gpu-operator ingress-nginx kube-node-lease kube-public kube-system load-generator opencost prometheus-system sealed-secrets"
+                    allowlist="chaoskube cnpg-system network-load-gen network-costs argo cert-manager default folding-at-home gpu-operator ingress-nginx kube-node-lease kube-public kube-system load-generator opencost prometheus-system sealed-secrets"
                     namespaces=$(kubectl get ns -o name | sed 's/namespace\///g')
               
                     for ns in ${namespaces}; do

--- a/argocd/apps/demo/chaoskube/values.yaml
+++ b/argocd/apps/demo/chaoskube/values.yaml
@@ -1,0 +1,36 @@
+# chaoskube is used to configure chaoskube
+chaoskube:
+  args: 
+    ######
+    # Example configuration, uncomment and adjust to your needs.
+    # Be sure to read: https://github.com/linki/chaoskube#flags
+    ######
+    # kill a pod every 20 minutes
+    interval: "20m"
+    # only target pods in the test environment
+    #labels: "app=speedtest-tracker"
+    # only consider pods with this annotation
+    #annotations: "chaos.alpha.kubernetes.io/enabled=true"
+    # exclude all DaemonSet pods
+    #kinds: "!DaemonSet"
+    # exclude all pods in the kube-system namespace
+    namespaces: "network-load-gen"
+    # don't kill anything on weekends
+    #excluded-weekdays: "Sat,Sun"
+    # don't kill anything during the night or at lunchtime
+    #excluded-times-of-day: "22:00-08:00,11:00-13:00"
+    # don't kill anything as a joke or on christmas eve
+    #excluded-days-of-year: "Apr1,Dec24"
+    # let's make sure we all agree on what the above times mean
+    #timezone: "UTC"
+    # exclude all pods that haven't been running for at least one hour
+    #minimum-age: "1h"
+    # terminate pods for real: this disables dry-run mode which is on by default
+    no-dry-run: ""
+
+# serviceAccount can be used to customize the service account which will be crated and used by chaoskube
+serviceAccount:
+  create: true
+
+
+

--- a/argocd/appsets/chaoskube-argo.yaml
+++ b/argocd/appsets/chaoskube-argo.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: chaoskube
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+  - git:
+      repoURL: https://github.com/opencost/opencost-infra.git
+      revision: main
+      files:
+      - path: "argocd/apps/*/chaoskube/values.yaml"
+  template:
+    metadata:
+      name: 'chaoskube-{{ index .path.segments 2 }}'
+      labels:
+        debug.argocd.argoproj.io/stage: '{{ index .path.segments 2 }}'
+    spec:
+      project: default
+      sources:
+        - repoURL: https://linki.github.io/chaoskube/
+          chart: chaoskube
+          targetRevision: 0.4.0
+          helm:
+            valueFiles:
+            - '$values/argocd/apps/{{ index .path.segments 2 }}/chaoskube/values.yaml'
+        - repoURL: https://github.com/opencost/opencost-infra.git
+          targetRevision: main
+          ref: values
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: chaoskube
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+        - CreateNamespace=true 


### PR DESCRIPTION
adds chaoskube, which kills pods in the network load generator namespace. this allows PVCs to be shared by pods in the same window for testing