### PR TITLE
Revert "Release v1.117.3 of Opencost"

### DIFF
--- a/argocd/apps/demo/opencost/values.yaml
+++ b/argocd/apps/demo/opencost/values.yaml
@@ -19,10 +19,14 @@ opencost:
         - secretName: opencost-tls
           hosts:
             - demo.infra.opencost.io
+    image:
+      fullImageName: ghcr.io/opencost/opencost-ui:develop-c855f42
   prometheus:
     internal:
       serviceName: prometheus-kube-prometheus-prometheus
       port: 9090
   exporter:
+    image:
+      fullImageName: ghcr.io/opencost/opencost:develop-14a3a79
     prometheusDataSource:
       queryResolutionSeconds: "60"


### PR DESCRIPTION
Reverts opencost/opencost-infra#172 after syncing Argo and validating changes. 